### PR TITLE
Fix module for futurize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,4 +102,4 @@ ENV/
 pyvenv.cfg
 .venv
 pip-selfcheck.json
-
+.idea/

--- a/apiclient/http.py
+++ b/apiclient/http.py
@@ -27,7 +27,11 @@ from builtins import range
 from builtins import object
 __author__ = 'jcgregorio@google.com (Joe Gregorio)'
 
-import six
+# [py2to3]TODO: remove StringIO.StringIO after upgrading to Py3
+try:
+    from StringIO import StringIO  # for Python 2
+except ImportError:
+    from io import StringIO  # for Python 3
 import base64
 import copy
 import gzip
@@ -470,7 +474,7 @@ class MediaInMemoryUpload(MediaIoBaseUpload):
     resumable: bool, True if this is a resumable upload. False means upload
       in a single request.
     """
-    fd = io.StringIO(body)
+    fd = StringIO(body)
     super(MediaInMemoryUpload, self).__init__(fd, mimetype, chunksize=chunksize,
                                               resumable=resumable)
 
@@ -1112,9 +1116,7 @@ class BatchHttpRequest(object):
       msg['content-length'] = str(len(request.body))
 
     # Serialize the mime message.
-    # TODO: Use io.StringIO after we update it to support only Py3
-    # due to https://stackoverflow.com/a/53733162/6396021
-    fp = six.StringIO()
+    fp = StringIO()
     # maxheaderlen=0 means don't line wrap headers.
     g = Generator(fp, maxheaderlen=0)
     g.flatten(msg, unixfrom=False)

--- a/apiclient/http.py
+++ b/apiclient/http.py
@@ -1104,7 +1104,7 @@ class BatchHttpRequest(object):
 
     for key, value in headers.items():
       msg[key] = value
-    msg['Host'] = unicode(parsed.netloc, 'utf-8')
+    msg['Host'] = parsed.netloc
     msg.set_unixfrom(None)
 
     if request.body is not None:

--- a/apiclient/http.py
+++ b/apiclient/http.py
@@ -704,9 +704,8 @@ class HttpRequest(object):
       self.headers['content-type'] = 'application/x-www-form-urlencoded'
       parsed = urllib.parse.urlparse(self.uri)
       self.uri = urllib.parse.urlunparse(
-          (parsed.scheme, parsed.netloc, parsed.path, parsed.params, '',
-           '')
-          )
+        parsed.scheme, parsed.netloc, parsed.path, parsed.params, '', ''
+      )
       self.body = parsed.query
       self.headers['content-length'] = str(len(self.body))
 
@@ -1088,8 +1087,8 @@ class BatchHttpRequest(object):
     # Construct status line
     parsed = urllib.parse.urlparse(request.uri)
     request_line = urllib.parse.urlunparse(
-        ('', '', parsed.path, parsed.params, parsed.query, '')
-        )
+      '', '', parsed.path, parsed.params, parsed.query, ''
+    )
     status_line = request.method + ' ' + request_line + ' HTTP/1.1\n'
     major, minor = request.headers.get('content-type', 'application/json').split('/')
     msg = MIMENonMultipart(major, minor)

--- a/apiclient/http.py
+++ b/apiclient/http.py
@@ -27,7 +27,7 @@ from builtins import range
 from builtins import object
 __author__ = 'jcgregorio@google.com (Joe Gregorio)'
 
-import io
+from io import BytesIO as StringIO
 import base64
 import copy
 import gzip
@@ -1112,7 +1112,7 @@ class BatchHttpRequest(object):
       msg['content-length'] = str(len(request.body))
 
     # Serialize the mime message.
-    fp = io.StringIO()
+    fp = StringIO()
     # maxheaderlen=0 means don't line wrap headers.
     g = Generator(fp, maxheaderlen=0)
     g.flatten(msg, unixfrom=False)

--- a/apiclient/http.py
+++ b/apiclient/http.py
@@ -1112,6 +1112,8 @@ class BatchHttpRequest(object):
       msg['content-length'] = str(len(request.body))
 
     # Serialize the mime message.
+    # TODO: Use io.StringIO after we update it to support only Py3
+    # due to https://stackoverflow.com/a/53733162/6396021
     fp = six.StringIO()
     # maxheaderlen=0 means don't line wrap headers.
     g = Generator(fp, maxheaderlen=0)

--- a/apiclient/http.py
+++ b/apiclient/http.py
@@ -704,7 +704,7 @@ class HttpRequest(object):
       self.headers['content-type'] = 'application/x-www-form-urlencoded'
       parsed = urllib.parse.urlparse(self.uri)
       self.uri = urllib.parse.urlunparse(
-        parsed.scheme, parsed.netloc, parsed.path, parsed.params, '', ''
+        (parsed.scheme, parsed.netloc, parsed.path, parsed.params, '', '')
       )
       self.body = parsed.query
       self.headers['content-length'] = str(len(self.body))
@@ -1086,8 +1086,9 @@ class BatchHttpRequest(object):
     """
     # Construct status line
     parsed = urllib.parse.urlparse(request.uri)
+    print("Parsed result: ", parsed)
     request_line = urllib.parse.urlunparse(
-      '', '', parsed.path, parsed.params, parsed.query, ''
+      ('', '', parsed.path, parsed.params, parsed.query, '')
     )
     status_line = request.method + ' ' + request_line + ' HTTP/1.1\n'
     major, minor = request.headers.get('content-type', 'application/json').split('/')

--- a/apiclient/http.py
+++ b/apiclient/http.py
@@ -1088,7 +1088,7 @@ class BatchHttpRequest(object):
     parsed = urllib.parse.urlparse(request.uri)
     print("Parsed result: ", parsed)
     request_line = urllib.parse.urlunparse(
-      ('', '', parsed.path, parsed.params, parsed.query, '')
+      (u'', u'', parsed.path, parsed.params, parsed.query, u'')
     )
     status_line = request.method + ' ' + request_line + ' HTTP/1.1\n'
     major, minor = request.headers.get('content-type', 'application/json').split('/')

--- a/apiclient/http.py
+++ b/apiclient/http.py
@@ -1104,7 +1104,7 @@ class BatchHttpRequest(object):
 
     for key, value in headers.items():
       msg[key] = value
-    msg['Host'] = parsed.netloc
+    msg['Host'] = unicode(parsed.netloc, 'utf-8')
     msg.set_unixfrom(None)
 
     if request.body is not None:

--- a/apiclient/http.py
+++ b/apiclient/http.py
@@ -704,7 +704,7 @@ class HttpRequest(object):
       self.headers['content-type'] = 'application/x-www-form-urlencoded'
       parsed = urllib.parse.urlparse(self.uri)
       self.uri = urllib.parse.urlunparse(
-        (parsed.scheme, parsed.netloc, parsed.path, parsed.params, '', '')
+        (parsed.scheme, parsed.netloc, parsed.path, parsed.params, u'', u'')
       )
       self.body = parsed.query
       self.headers['content-length'] = str(len(self.body))
@@ -1086,7 +1086,6 @@ class BatchHttpRequest(object):
     """
     # Construct status line
     parsed = urllib.parse.urlparse(request.uri)
-    print("Parsed result: ", parsed)
     request_line = urllib.parse.urlunparse(
       (u'', u'', parsed.path, parsed.params, parsed.query, u'')
     )

--- a/apiclient/http.py
+++ b/apiclient/http.py
@@ -27,7 +27,7 @@ from builtins import range
 from builtins import object
 __author__ = 'jcgregorio@google.com (Joe Gregorio)'
 
-from io import BytesIO as StringIO
+import six
 import base64
 import copy
 import gzip
@@ -1112,7 +1112,7 @@ class BatchHttpRequest(object):
       msg['content-length'] = str(len(request.body))
 
     # Serialize the mime message.
-    fp = StringIO()
+    fp = six.StringIO()
     # maxheaderlen=0 means don't line wrap headers.
     g = Generator(fp, maxheaderlen=0)
     g.flatten(msg, unixfrom=False)


### PR DESCRIPTION
## Context
We have upgraded this module to support Py3 in PR #1. 
We have merged the update to Rbox app in https://github.com/Aplopio/recruiterbox/pull/24903 but had to revert it due to below sentry issue. 
https://sentry.io/organizations/recruiterbox/issues/1239987447/?project=238626&referrer=slack

## Issue
We were unable to make a call to Google apis as futurize was raising exceptions while forming the request. The reason being we were passing combination of None and str values in `urllib.parse.urlunparse` (Py3) which is updated syntax of `urlparse.urlparse` (Py2). Futurize breaks if the inputs passed to `urlunparse` are of different types. In our case, some of the values passed were None and some unicode. 
This is a known issue in futurize which is marked with `won't fix` label. https://github.com/PythonCharmers/python-future/issues/273 

## Fix
- We are passing `u''` i.e. unicode empty string to fix the above behaviour. 

## Testing the fix
We have added a test in `recruiterbox` repo in PR 
https://github.com/Aplopio/recruiterbox/pull/24994. 
This test makes a call to Google API even though we get a `AccessTokenCredentialsError` in response. This makes sure that we don't face above issue while forming the request. 

## New issue found
`StringIO.StringIO` in Py2 is now `io.StringIO` in Py3. Futurize converted this syntax when we updated in our last PR #1. 
But that implementation failed with below error
`TypeError: unicode argument expected, got 'str'`. 
If we change the `io.StringIO` which takes unicode stream to `io.BytesIO` which support bytes stream as suggested in [this](https://github.com/pdfminer/pdfminer.six/issues/161#issuecomment-402628643) link, it again fails with below error
`TypeError: 'unicode' does not have the buffer interface`. 

Got another [fix](https://stackoverflow.com/a/53733162/6396021) where it has been suggested to use `six.StringIO` which import StringIO.StringIO in Python 2.x and the appropriate class from io in Python 3.x. But this again comes with a caveat mentioned in link above. 

But I decided to move forward with `six` module for now. Once, we upgrade to Py3 completely and remove backward compatibility to Py2.7 we will move it to `io.StringIO`. Added a TODO comment for the same. 

## Notes for reviewers
- Unfortunately I can't give further technical details about `StringIO` and how it works under the hood. As I am still unsure about it. Let me know if you guys want to discuss about it. I have just made it work for now 😛 
- Once this PR is approved, I will merge it to main and create a new version of the repo and use it in PR https://github.com/Aplopio/recruiterbox/pull/24994 `requirements.txt` file. 