### PR TITLE
Fixed error while doing ord operation on bytes in validate_token function. The below operation will always fail because ord operation on byte is invalid.

### DIFF
--- a/oauth2client/xsrfutil.py
+++ b/oauth2client/xsrfutil.py
@@ -68,7 +68,7 @@ def generate_token(key, user_id, action_id="", when=None):
 
   token = base64.urlsafe_b64encode(digest + DELIMITER + when)
 
-  return token
+  return token.decode('utf-8')
 
 
 @util.positional(3)
@@ -110,7 +110,7 @@ def validate_token(key, token, user_id, action_id="", current_time=None):
 
   # Perform constant time comparison to avoid timing attacks
   different = 0
-  for x, y in zip(bytearray(token, 'utf-8'), bytearray(expected_token, 'utf-8')):
+  for x, y in zip(token, expected_token):
     different |= ord(x) ^ ord(y)
   if different:
     return False


### PR DESCRIPTION
Changed return type of generate_token in xsrfutil from bytes to string.

Changed return type from bytes to string as it is meant to return string
```
@util.positional(2)
def generate_token(key, user_id, action_id="", when=None):
  ...
  return token.decode('utf-8')
```

Fixed error while doing ord operation on bytes in validate_token function. The below operation will always fail because ord operation on byte is invalid.
```
for x, y in zip(bytearray(token, 'utf-8'), bytearray(expected_token, 'utf-8')):
      different |= ord(x) ^ ord(y)
```